### PR TITLE
arbel-evb: change I2C_MASTER and I2C_SALVE bus number for stress test

### DIFF
--- a/data/arbel-evb/variables.py
+++ b/data/arbel-evb/variables.py
@@ -1,7 +1,7 @@
 BOARD_TEST_MSG = "hallo arble-evb"
 # I2C
-I2C_MASTER = "4"
-I2C_SALVE = "3"
+I2C_MASTER = "2"
+I2C_SALVE = "1"
 # Network
 NET_PRIMARY_INTF = "eth1"
 NET_PRIMARY_THR = "550"


### PR DESCRIPTION
Original cross wiring i2c module 3 & 4 on Arbel EVB J3 header for stress test.
We found that i2c module 3's voltage level is around 3.12v~3.14v on two Arbel EVB.

The test got failed since the npcm_i2c_init_module checks that the SCL/SDA
level is low and the driver fails to probe i2c module 3.

The other i2c module 1 & 2 on Arbel EVB J3 header is normal 3.3v.
According current Arbel EVB design, we need to change i2c module to 1 & 2 for test.

Verify:
robot -i i2c test_basic.robot

Signed-off-by: Tim Lee <timlee660101@gmail.com>