### PR TITLE
data: script: fix argument list too long then cause net stress test fail

### DIFF
--- a/data/net_test.sh
+++ b/data/net_test.sh
@@ -174,7 +174,7 @@ do
 	echo  >> $log_file
 	echo "timestamp = $run_end_time sec">> $log_file
 	echo $iperf_cmd >> $log_file
-	cat $tmp_file | tee -a $log_file
+	cat $tmp_file >> $log_file
 	### end of updating log file
 
 done


### PR DESCRIPTION
Verify:
robot -t "Primary Interface Net Stress Test" test_basic.robot

Signed-off-by: Tim Lee <timlee660101@gmail.com>