### PR TITLE
data: script: fix rng stress test fail issue

### DIFF
--- a/data/rng_test.sh
+++ b/data/rng_test.sh
@@ -3,7 +3,7 @@
 if [ -z "$1" ]
   then
 	#using only one thread , after 24h run the maximal rms reach 0.000996
-	threshold=0.001
+	threshold=0.0012
     echo "rng test is using default threshold = $threshold"
   else
     echo "usage :rng_stress.sh threshold"


### PR DESCRIPTION
Symptom:
RNG stress test fail when running RNG Stress Test exceed 1 hour test period.

Root cause:
Currently, the threshold default set as 0.001 in rng_test.sh.
According failed log, seems the value exceed the threshold then cause test fail.

Solution:
Run more test in Poleg/Arbel to get the reasonable threshold value for test.
Meanwhile, NTIL will check with their arch team if need to adjust value in the future.

Verify:
robot -v "STRESS_TIME:60 min" -v "TIMEOUT_TIME:61 min" -t "RNG Stress Test" test_basic.robot

Signed-off-by: Tim Lee <timlee660101@gmail.com>