### PR TITLE
arbel-evb: Update SGPIO script to skip gpio 66~69

### DIFF
--- a/data/arbel-evb/sgpio_test.sh
+++ b/data/arbel-evb/sgpio_test.sh
@@ -4,20 +4,20 @@ set -e
 for ((i=1;i<=10;i++))
 do
 	log_file="/tmp/log/sgpio_test.$i.log"
-	gpiomon -n 32 8 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79  > $log_file &
+	gpiomon -n 24 8 64 65 70 71 72 73 74 75 76 77 78 79  > $log_file &
 
 	t=0
-	while [ "$t" != "16" ]
+	while [ "$t" != "13" ]
 	do
-		t=$(ps |  grep  "gpiomon]" | awk 'BEGIN{y=0;x=94}{ x++ ; s="[irq/"x"-gpiomon]" ;if(s == $5) y++ ; if(y==16){print y ; exit}}')
+		t=$(ps |  grep  "gpiomon]" | wc -l)
 	done
 
-	gpioset 8 0=1 1=1 2=1 3=1 4=1 5=1 6=1 7=1 8=1 9=1 10=1 11=1 12=1 13=1 14=1 15=1
-	gpioset 8 0=0 1=0 2=0 3=0 4=0 5=0 6=0 7=0 8=0 9=0 10=0 11=0 12=0 13=0 14=0 15=0
+	gpioset 8 0=1 1=1 6=1 7=1 8=1 9=1 10=1 11=1 12=1 13=1 14=1 15=1
+	gpioset 8 0=0 1=0 6=0 7=0 8=0 9=0 10=0 11=0 12=0 13=0 14=0 15=0
 
-	Pin_Count=$(awk 'BEGIN{x=0;y=0}{ y++ ; x+=$5 ; if(y==32) print x ;}' $log_file)
-	#echo $i:$Pin_Count
-	if [ "$Pin_Count" != "2288" ]
+	Pin_Count=$(awk 'BEGIN{x=0;y=0}{ y++ ; x+=$5 ; if(y==24) print x ;}' $log_file)
+	echo $i:$Pin_Count
+	if [ "$Pin_Count" != "1748" ]
 	then
 		echo FAIL  >> $log_file
 		exit 1

--- a/test_basic.robot
+++ b/test_basic.robot
@@ -123,6 +123,20 @@ AES Stress Test
 		Exit For Loop If    ${diff} > ${stress_time_sec}
 	END
 
+SGPIO Stress Test
+	[Documentation]  SGPIO stress test
+	[Tags]  Stress Test  Onboard  HWsetup  SGPIO
+
+	${start}=  Get Time  epoch
+	${stress_time_sec}=  Convert Time  ${STRESS_TIME}
+	Rprint Vars  stress_time_sec
+	FOR  ${count}  IN RANGE  1  99999
+		Test Script And Verify  ${SGPIO_SCRIPT}  @{BOARD_SUPPORTED}  quiet=1
+		${now}=  Get Time  epoch
+		${diff}=  Evaluate  ${now} - ${start}
+		Exit For Loop If    ${diff} > ${stress_time_sec}
+	END
+
 PSPI Stress Test
 	[Documentation]  PSPI stress test
 	[Tags]  Stress Test  Onboard  HWsetup  PSPI


### PR DESCRIPTION
1.Skip gpio 66~69 which are dedicated for power-control
2.Add SGPIO Stress Test

Signed-off-by: Medad CChien <ctcchien@nuvoton.com>