### PR TITLE
arbel-evb: add TPM and Cerberus unit and stress test

### DIFF
--- a/data/arbel-evb/cerberus_test.sh
+++ b/data/arbel-evb/cerberus_test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+log_file="/tmp/cerberus.log"
+
+cerberus_utility fwversion > /dev/null
+if [ "$?" == "0" ]; then
+	cerberus_utility fwversion 0 | grep "Cerberus Version" > $log_file
+	cerberus_utility fwversion 1 | grep "RIoT Core Version" >> $log_file
+	if [ `cerberus_utility testerror | grep -i "fail|error|Invalid"` >> $log_file ]; then
+		exit 1
+	else
+		echo "Test completed successfully." >> $log_file
+	fi
+	echo "Cerberus command completed successfully." >> $log_file
+else
+	echo "Cerberus command failed." > $log_file
+	exit 1
+fi
+
+echo "cerberus test finished"
+exit 0

--- a/data/arbel-evb/gpio_test.sh
+++ b/data/arbel-evb/gpio_test.sh
@@ -6,28 +6,19 @@ rc=0
 echo fff02000.i2c > /sys/bus/platform/drivers/nuvoton-i2c/unbind >& /dev/null
 sleep 1
 
-echo 0 > /sys/class/gpio/export 2>/dev/null
-echo 1 > /sys/class/gpio/export 2>/dev/null
-
-set -e
-echo out > /sys/class/gpio/gpio0/direction
-echo in  > /sys/class/gpio/gpio1/direction
-
-echo 1 > /sys/class/gpio/gpio0/value
-val=`cat /sys/class/gpio/gpio1/value`
+gpioset 0 0=1
+val=`gpioget 0 1`
 if [ $val -ne 1 ]; then
         echo "FAIL: gpio1 should be 1"
         rc=1
 fi
-echo 0 > /sys/class/gpio/gpio0/value
-val=`cat /sys/class/gpio/gpio1/value`
+gpioset 0 0=0
+val=`gpioget 0 1`
 if [ $val -ne 0 ]; then
         echo "FAIL: gpio1 should be 0"
         rc=1
 fi
 
-echo 0 > /sys/class/gpio/unexport
-echo 1 > /sys/class/gpio/unexport
 echo fff02000.i2c > /sys/bus/platform/drivers/nuvoton-i2c/bind >& /dev/null
 
 echo "PASS"

--- a/data/arbel-evb/tpm_test.sh
+++ b/data/arbel-evb/tpm_test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+log_file="/tmp/ftpm.log"
+
+if test -e "/dev/tpm0";	then
+	echo "ftpm device exist." > $log_file
+else
+	echo "ftpm device does not exist!!" > $log_file
+	exit 1
+fi
+
+# Full test - TPM will test all functions regardless of what has already been tested
+tpm2_selftest -f
+if [ "$?" == "0" ]; then
+	echo "tpm2 selftest passed" >> $log_file
+else
+	echo "tpm2 selftest failed!!" >> $log_file
+	exit 1
+fi
+
+echo "ftpm test finished"
+exit 0

--- a/data/arbel-evb/variables.py
+++ b/data/arbel-evb/variables.py
@@ -14,8 +14,8 @@ NET_SECONDARY_THR = ["60", "550"]
 SPI_DEV = "mtdblock7"
 MMC_DEV = "mmcblk0p6"
 USB_DEV = "sda6"
-# GPIO, SMB18, J4
-GPIO_PINS = ["0", "1"]
+# GPIO, SMB18, J4, in linux 6.6, gpio num should add 512 (GPIO_DYNAMIC_BASE=512)
+GPIO_PINS = ["512", "513"]
 # ADC
 ADC_CHANNEL = "5"
 ADC_REF_VOLT = "1.2"

--- a/test_basic.robot
+++ b/test_basic.robot
@@ -28,6 +28,8 @@ ${AES_SCRIPT}		aes_test.sh
 ${PSPI_SCRIPT}		pspi_test.sh
 ${SGPIO_SCRIPT}		sgpio_test.sh
 ${SHA_SCRIPT}		sha_test.sh
+${TPM_SCRIPT}		tpm_test.sh
+${CERBERUS_SCRIPT}	cerberus_test.sh
 ${ignore_err}		${0}
 
 *** Test Cases ***
@@ -102,6 +104,22 @@ TMPS Unit Test
 
 	# script
 	${TMPS_SCRIPT}  arbel-evb
+
+TPM Unit Test
+	[Documentation]  TPM test
+	[Tags]  Basic  Onboard  HWsetup  TPM
+	[Template]  Test Script And Verify
+
+	# script
+	${TPM_SCRIPT}  @{BOARD_SUPPORTED}
+
+Cerberus Unit Test
+	[Documentation]  Cerberus test
+	[Tags]  Basic  Onboard  HWsetup  Cerberus
+	[Template]  Test Script And Verify
+
+	# script
+	${CERBERUS_SCRIPT}  @{BOARD_SUPPORTED}
 
 SHA Stress Test
 	[Documentation]  SHA stress test
@@ -361,6 +379,34 @@ I2C Slave EEPROM Stress Test
 	...  ${I2C_MASTER}  ${I2C_SALVE}  ${I2C_EEPROM_ADDR}
 	...  script=${I2C_SCRIPT}
 	[Teardown]  Run Keywords  Simple Get Test State information  Collect Log On Test Case Fail
+
+TPM Stress Test
+	[Documentation]  TPM stress test
+	[Tags]  Stress Test  Onboard  HWsetup  TPM
+
+	${start}=  Get Time  epoch
+	${stress_time_sec}=  Convert Time  ${STRESS_TIME}
+	Rprint Vars  stress_time_sec
+	FOR  ${count}  IN RANGE  1  99999
+		Test Script And Verify  ${TPM_SCRIPT}  @{BOARD_SUPPORTED}  quiet=1
+		${now}=  Get Time  epoch
+		${diff}=  Evaluate  ${now} - ${start}
+		Exit For Loop If    ${diff} > ${stress_time_sec}
+	END
+
+Cerberus Stress Test
+	[Documentation]  Cerberus stress test
+	[Tags]  Stress Test  Onboard  HWsetup  Cerberus
+
+	${start}=  Get Time  epoch
+	${stress_time_sec}=  Convert Time  ${STRESS_TIME}
+	Rprint Vars  stress_time_sec
+	FOR  ${count}  IN RANGE  1  99999
+		Test Script And Verify  ${CERBERUS_SCRIPT}  @{BOARD_SUPPORTED}  quiet=1
+		${now}=  Get Time  epoch
+		${diff}=  Evaluate  ${now} - ${start}
+		Exit For Loop If    ${diff} > ${stress_time_sec}
+	END
 
 Test Hello World
 	[Documentation]  Hello world


### PR DESCRIPTION
Verify:
robot -t "TPM Unit Test" -v BOARD:arbel-evb test_basic.robot robot -t "TPM Stress Test" -v BOARD:arbel-evb test_basic.robot robot -t "Cerberus Unit Test" -v BOARD:arbel-evb test_basic.robot robot -t "Cerberus Stress Test" -v BOARD:arbel-evb test_basic.robot

Note, in Linux 6.6 if Using legacy sysfs-based GPIO, the GPIO pin should add 512 (GPIO_DYNAMIC_BASE=512)